### PR TITLE
Rename misnamed cursor centering method

### DIFF
--- a/src/Utilities/Mouse.cs
+++ b/src/Utilities/Mouse.cs
@@ -49,7 +49,8 @@ namespace AimBot.Utilities
         /// <param name="position"></param>
         /// <param name="gameWindow"></param>
         /// <returns></returns>
-        public static bool SetCurosPosToCenterOfRec(RectangleF position, RectangleF gameWindow) => SetCursorPos((int) (gameWindow.X + position.Center.X), (int) (gameWindow.Y + position.Center.Y));
+        public static bool SetCursorPosToCenterOfRect(RectangleF position, RectangleF gameWindow) =>
+            SetCursorPos((int) (gameWindow.X + position.Center.X), (int) (gameWindow.Y + position.Center.Y));
 
         /// <summary>
         ///     Retrieves the cursor's position, in screen coordinates.


### PR DESCRIPTION
## Summary
- correct typo in mouse utility: SetCursorPosToCenterOfRect

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a84fb0db4c832eb57cadd142ff4625