### PR TITLE
Refactor entity distance to use player position

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -17,7 +17,7 @@
 
 ### 3. Distance Calculation Problem
 **Problem**: `Misc.EntityDistance()` was using `Player.Entity.Pos` which could be null.
-**Fix**: Changed to use `GameController.Player.Pos` directly with `Vector3.Distance()`.
+**Fix**: Updated `Misc.EntityDistance` to take the player's position (from `GameController.Player.Pos`) and compute distance with `Vector3.Distance()`.
 
 ### 4. Enhanced Debugging
 **Problem**: Not enough visibility into what the plugin is detecting.

--- a/src/Core/Main.cs
+++ b/src/Core/Main.cs
@@ -693,7 +693,7 @@ namespace Aimbot.Core
                                                                      && TryGetStat("ignored_by_enemy_target_selection", x) == 0
                                                                      && TryGetStat("cannot_die", x) == 0
                                                                      && TryGetStat("cannot_be_damaged", x) == 0)
-                                                            .Select(x => new Tuple<float, Entity>(Misc.EntityDistance(x), x))
+                                                            .Select(x => new Tuple<float, Entity>(Misc.EntityDistance(x, GameController.Player.Pos), x))
                                                             .OrderBy(x => x.Item1)
                                                             .ToList();
             
@@ -1098,7 +1098,7 @@ namespace Aimbot.Core
                 Entity m = entity;
                 int weight = 0;
                 
-                // Use direct distance calculation instead of Misc.EntityDistance which might fail
+                // Calculate distance from the player's position for weighting
                 if (GameController?.Player != null)
                 {
                     var distance = Vector3.Distance(GameController.Player.Pos, m.Pos);

--- a/src/Utilities/Misc.cs
+++ b/src/Utilities/Misc.cs
@@ -7,23 +7,11 @@ namespace AimBot.Utilities
 {
     public class Misc
     {
-        //public static int EntityDistance(Entity entity)
-        //{
-        //    var Object = entity.GetComponent<Render>();
-        //    return (int) Math.Sqrt(Math.Pow(Player.X - Object.X, 2) + Math.Pow(Player.Y - Object.Y, 2));
-        //}
-
-        public static int EntityDistance(Entity entity)
+        public static int EntityDistance(Entity entity, Vector3 playerPos)
         {
-            var Object = entity.GetComponent<Render>();
-            return Convert.ToInt32(Vector3.Distance(Player.Entity.Pos, Object.Pos));
+            var render = entity.GetComponent<Render>();
+            return Convert.ToInt32(Vector3.Distance(playerPos, render.Pos));
         }
-
-        //public static int EntityDistance(Entity entity)
-        //{
-        //    var Object = entity.GetComponent<Render>();
-        //    return (int)Math.Sqrt(Math.Pow(Player.X - Object.X, 2) + Math.Pow(Player.Y - Object.Y, 2));
-        //}
 
         public static int GetEntityDistance(Vector2 firstPos, Vector2 secondPos)
         {


### PR DESCRIPTION
## Summary
- compute distances using player position rather than `Player.Entity`
- update caller to supply `GameController.Player.Pos`
- clarify troubleshooting documentation

## Testing
- `dotnet build src/'Aim Bot.csproj'` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68a84fc25b4c832e89b6a53456cb4263