### PR TITLE
Add line-of-sight tests

### DIFF
--- a/AimBot.Tests/AimBot.Tests.csproj
+++ b/AimBot.Tests/AimBot.Tests.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../src/Aim Bot.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+</Project>

--- a/AimBot.Tests/LineOfSightTests.cs
+++ b/AimBot.Tests/LineOfSightTests.cs
@@ -1,0 +1,52 @@
+using System.Reflection;
+using SharpDX;
+using Xunit;
+using AimBot.Core;
+
+namespace AimBot.Tests
+{
+    public class LineOfSightTests
+    {
+        private Main CreateMain(byte[,] tiles)
+        {
+            var main = new Main();
+            typeof(Main).GetField("_terrainTiles", BindingFlags.NonPublic | BindingFlags.Instance)!
+                .SetValue(main, tiles);
+            typeof(Main).GetField("_numRows", BindingFlags.NonPublic | BindingFlags.Instance)!
+                .SetValue(main, tiles.GetLength(1));
+            typeof(Main).GetField("_numCols", BindingFlags.NonPublic | BindingFlags.Instance)!
+                .SetValue(main, tiles.GetLength(0));
+            typeof(Main).GetField("_terrainDataLoaded", BindingFlags.NonPublic | BindingFlags.Instance)!
+                .SetValue(main, true);
+            return main;
+        }
+
+        [Fact]
+        public void HasLineOfSight_ReturnsFalse_WhenPathBlocked()
+        {
+            var grid = new byte[3,3]
+            {
+                {1,1,1},
+                {1,255,1},
+                {1,1,1}
+            };
+            var main = CreateMain(grid);
+            var result = main.HasLineOfSight(new Vector3(0,0,0), new Vector3(2,2,0));
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void HasLineOfSight_ReturnsTrue_WhenPathClear()
+        {
+            var grid = new byte[3,3]
+            {
+                {1,1,1},
+                {1,255,1},
+                {1,1,1}
+            };
+            var main = CreateMain(grid);
+            var result = main.HasLineOfSight(new Vector3(0,0,0), new Vector3(0,2,0));
+            Assert.True(result);
+        }
+    }
+}

--- a/src/Core/Main.cs
+++ b/src/Core/Main.cs
@@ -1588,7 +1588,7 @@ namespace Aimbot.Core
         /// <param name="startPos">Starting world position (usually player position)</param>
         /// <param name="endPos">Target world position (usually monster position)</param>
         /// <returns>True if line of sight is clear, false if blocked by terrain</returns>
-        private bool HasLineOfSight(Vector3 startPos, Vector3 endPos)
+        internal bool HasLineOfSight(Vector3 startPos, Vector3 endPos)
         {
             try
             {
@@ -1673,7 +1673,7 @@ namespace Aimbot.Core
         /// <summary>
         /// Converts world position to grid coordinates for terrain lookup
         /// </summary>
-        private Vector2 WorldToGridPosition(Vector3 worldPos)
+        internal Vector2 WorldToGridPosition(Vector3 worldPos)
         {
             // This conversion may need adjustment based on how ExileCore maps world to grid coordinates
             // For now using a basic conversion similar to what the Follower plugin uses
@@ -1683,7 +1683,7 @@ namespace Aimbot.Core
         /// <summary>
         /// Checks if grid position is within terrain bounds
         /// </summary>
-        private bool IsValidGridPosition(Vector2 gridPos)
+        internal bool IsValidGridPosition(Vector2 gridPos)
         {
             return gridPos.X >= 0 && gridPos.X < _numCols && 
                    gridPos.Y >= 0 && gridPos.Y < _numRows;

--- a/src/Properties/AssemblyInfo.cs
+++ b/src/Properties/AssemblyInfo.cs
@@ -1,0 +1,2 @@
+using System.Runtime.CompilerServices;
+[assembly: InternalsVisibleTo("AimBot.Tests")]


### PR DESCRIPTION
## Summary
- expose line-of-sight helper methods for testing
- add InternalsVisibleTo for AimBot.Tests
- add tests verifying blocked vs clear paths

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a84fc3be1c832e9edb825e870695b6