### PR TITLE
Fail build when ExileCore dependencies are missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ The plugin includes intelligent line of sight checking to prevent targeting mons
 
 ### Prerequisites
 1. **ExileCore/ExileAPI** installed and working
-2. **Environment Variable**: Set `exapiPackage` to your ExileApi-Compiled-master folder path
+2. **Environment Variable**: Set `exapiPackage` to the directory containing `ExileCore.dll` and `GameOffsets.dll` (e.g., the [ExileApi-Compiled](https://github.com/exApiTools/ExileApi-Compiled) repository)
 
 ### Installation
 1. **Clone/Download** this repository

--- a/src/Aim Bot.csproj
+++ b/src/Aim Bot.csproj
@@ -10,6 +10,9 @@
     <EmbedAllSources>true</EmbedAllSources>
     <!--Don't bother setting anything to do with the output path, HUD will do it for you if you put the source code inside Plugins/Source-->
   </PropertyGroup>
+  
+  <Error Condition="'$(exapiPackage)' == ''"
+         Text="Set the 'exapiPackage' environment variable to the directory containing ExileCore.dll and GameOffsets.dll." />
 
   <ItemGroup>
     <!--Rather than replacing this with absolute or relative paths, you should create an environment variable for wherever your HUD folder is-->


### PR DESCRIPTION
## Summary
- Fail the build with a clear message when `exapiPackage` isn't set
- Document the `exapiPackage` environment variable and link to ExileApi-Compiled

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a85500a900832e9164216f9d533f50