### PR TITLE
Fix MSBuild error tag usage

### DIFF
--- a/src/Aim Bot.csproj
+++ b/src/Aim Bot.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk" InitialTargets="EnsureExapiPackage">
   <PropertyGroup>
     <TargetFramework>net8.0-windows</TargetFramework>
     <OutputType>Library</OutputType>
@@ -10,18 +10,20 @@
     <EmbedAllSources>true</EmbedAllSources>
     <!--Don't bother setting anything to do with the output path, HUD will do it for you if you put the source code inside Plugins/Source-->
   </PropertyGroup>
-  
-  <Error Condition="'$(exapiPackage)' == ''"
-         Text="Set the 'exapiPackage' environment variable to the directory containing ExileCore.dll and GameOffsets.dll." />
+
+  <Target Name="EnsureExapiPackage">
+    <Error Condition="'$(exapiPackage)' == ''"
+           Text="Set the 'exapiPackage' environment variable to the directory containing ExileCore.dll and GameOffsets.dll." />
+  </Target>
 
   <ItemGroup>
     <!--Rather than replacing this with absolute or relative paths, you should create an environment variable for wherever your HUD folder is-->
     <Reference Include="ExileCore">
-      <HintPath>$(exapiPackage)\ExileCore.dll</HintPath>
+      <HintPath>$(exapiPackage)\\ExileCore.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="GameOffsets">
-      <HintPath>$(exapiPackage)\GameOffsets.dll</HintPath>
+      <HintPath>$(exapiPackage)\\GameOffsets.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>


### PR DESCRIPTION
## Summary
- wrap exapiPackage error check in an EnsureExapiPackage target
- set InitialTargets to run the target before build

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a85d2431d0832eac0f13b5367ea68b